### PR TITLE
adds support for EntityDestroy packet

### DIFF
--- a/RustInterceptor/Data/Entity.cs
+++ b/RustInterceptor/Data/Entity.cs
@@ -100,7 +100,7 @@ namespace Rust_Interceptor.Data {
 			}
 		}
 
-		public static uint CreateOrUpdate(Packet p) {
+        public static uint CreateOrUpdate(Packet p) {
 			/* Entity Number/Order, for internal use */
 			var num = p.UInt32();
 			ProtoBuf.Entity proto = global::ProtoBuf.Entity.Deserialize(p);
@@ -114,9 +114,18 @@ namespace Rust_Interceptor.Data {
 				entities[id].num = num;
 			}
 			return id;
-		}
+        }
 
-		public Entity(ProtoBuf.Entity proto) {
+        public static bool Destroy(uint uid, byte destroy_mode)
+        {
+            if (entities.ContainsKey(uid) == true && destroy_mode == 0)
+            {
+                return entities.Remove(uid);
+            }
+            return false;
+        }
+
+        public Entity(ProtoBuf.Entity proto) {
 			protobuf = proto;
 			if (proto.basePlayer != null) player = new BasePlayer(proto.basePlayer);
 			if (proto.resource != null) resource = new BaseResource(proto.resource);

--- a/RustInterceptor/Data/EntityDestroy.cs
+++ b/RustInterceptor/Data/EntityDestroy.cs
@@ -1,14 +1,16 @@
-﻿namespace Rust_Interceptor.Data {
-	public class EntityDestroy {
-
-		internal uint uid;
+﻿namespace Rust_Interceptor.Data
+{
+	public class EntityDestroy
+    {
+        internal static uint uid;
 		public uint UID { get{ return uid; } }
-		internal byte destroyMode;
+		internal static byte destroyMode;
 		public byte DestroyMode { get{ return destroyMode; } }
 
-		public EntityDestroy(Packet p) {
+		public static bool Destroy(Packet p) {
 			uid = p.UInt32();
 			destroyMode = p.UInt8();
+            return Entity.Destroy(uid, destroyMode);
 		}
 	}
 }

--- a/RustInterceptor/RustInterceptor.cs
+++ b/RustInterceptor/RustInterceptor.cs
@@ -126,7 +126,7 @@ namespace Rust_Interceptor {
 		public void SavePackets(Packet[] packet, string filename = "packets.json", Newtonsoft.Json.Formatting formatting = Newtonsoft.Json.Formatting.Indented, bool informative = true) {
 			var outs = File.Create(filename);
 			Serializer.informativeDump = informative;
-			string json = Serializer.Serialize(packet);
+			string json = Serializer.Serialize(packet, informative);
 			outs.Write(Encoding.ASCII.GetBytes(json), 0, json.Length);
 			outs.Flush();
 			outs.Close();


### PR DESCRIPTION
Usage example
```cs
switch ((Packet.Rust)packet.packetID)
{
    case Packet.Rust.Entities:
        Rust_Interceptor.Data.Entity.CreateOrUpdate(packet);
        break;
    case Packet.Rust.EntityPosition:
        Rust_Interceptor.Data.Entity.UpdatePosition(packet);
        break;
    case Packet.Rust.EntityDestroy:
        Rust_Interceptor.Data.EntityDestroy.Destroy(packet);
        break;
    default:
        break;
}
```